### PR TITLE
note adblocker incompatibility with snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # spotify-adblock-linux
 Spotify adblocker for Linux that works by wrapping `getaddrinfo` and *libcurl*'s `curl_easy_setopt` and blocking all domains that aren't whitelisted, as well as blacklisted URLs.
 
+This adblocker is incompatible with the snap Spotify package.
+
 ## Building
     $ git clone https://github.com/abba23/spotify-adblock-linux.git
     $ cd spotify-adblock-linux


### PR DESCRIPTION
Took me a few minutes to figure out that I couldn't use the snap package. Figured adding that note to the readme would save others some time.