### PR TITLE
Makefile: move -fPIC and -shared out of CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Wall -shared -fPIC
+CFLAGS=-Wall
 LDLIBS=-ldl
 TARGET=spotify-adblock
 PREFIX=/usr/local/lib
@@ -8,7 +8,7 @@ PREFIX=/usr/local/lib
 all: $(TARGET).so
 
 $(TARGET).so: $(TARGET).c whitelist.h blacklist.h
-	$(CC) $(CFLAGS) -o $@ $(LDLIBS) $^
+	$(CC) $(CFLAGS) -shared -fPIC -o $@ $(LDLIBS) $^
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
CFLAGS can be overwritten by the environment, breaking compilation
because its now missing -shared.