### PR TITLE
Add new podcasts URL to whitelist

### DIFF
--- a/whitelist.h
+++ b/whitelist.h
@@ -31,4 +31,5 @@ static const char *whitelist[] = {
     "t.scdn.co", // background images
     "thisis-images.scdn.co", // 'this is' playlists images
     "video-fa.scdn.co", // videos
+    "*.libsyn.com", // podcasts
 };

--- a/whitelist.h
+++ b/whitelist.h
@@ -1,4 +1,6 @@
 static const char *whitelist[] = {
+    "traffic.libsyn.com", // podcasts
+    "hwcdn.libsyn.com", // podcasts
     "ap.spotify.com", // audio (access point)
     "*.ap.spotify.com", // resolved access points
     "apresolve.spotify.com", // access point resolving
@@ -31,5 +33,4 @@ static const char *whitelist[] = {
     "t.scdn.co", // background images
     "thisis-images.scdn.co", // 'this is' playlists images
     "video-fa.scdn.co", // videos
-    "*.libsyn.com", // podcasts
 };


### PR DESCRIPTION
This allows to load podcasts from libsyn.com. A podcast that required this patch is "The WAN Show Podcast". 