### PR TITLE
Actually link to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
-CFLAGS=-Wall
-LDLIBS=-ldl
+CFLAGS=-Wall -lcurl
+LDLIBS=-ldl -lcurl
 TARGET=spotify-adblock
 PREFIX=/usr/local
 


### PR DESCRIPTION
PROBLEM:

❯ LD_PRELOAD="/usr/lib/spotify-adblock.so /usr/lib/spotifywm.so" spotify-tray -m -- --force-device-scale-factor=2 &
[1] 99474
spotify-tray: symbol lookup error: /usr/lib/spotify-adblock.so: undefined symbol: curl_easy_cleanup

SOLUTION:
Specify libcurl in compile and link flags.