### PR TITLE
Strip the built libary during make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+cef.tar.bz2
+include/
 *.so

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PREFIX=/usr/local
 all: $(TARGET).so
 
 $(TARGET).so: $(TARGET).c whitelist.h blacklist.h
-	$(CC) $(CFLAGS) -shared -fPIC -o $@ $(LDFLAGS) $(LDLIBS) $^
+	$(CC) $(CFLAGS) -shared -fPIC -s -o $@ $(LDFLAGS) $(LDLIBS) $^
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
rpmlint complains otherwise.

It might be a better idea to add `-s` to the install during `install:` tho