### PR TITLE
Add support for spicetify's Reddit/YouTube custom app

### DIFF
--- a/whitelist.h
+++ b/whitelist.h
@@ -25,17 +25,15 @@ static const char *whitelist[] = {
     "*.buzzsprout.com", // podcasts
     "platform-lookaside.fbsbx.com", // Facebook profile images
     "genius.com", // lyrics (genius-spicetify)
+    "*.googlevideo.com", // YouTube videos (Spicetify Reddit app)
     "*.gvt1.com", // Widevine download
-    "www.reddit.com", // reddit content (https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit)
-    "www.youtube.com", // YouTube entry (https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit)
-    "i.ytimg.com", // YouTube thumbnail (https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit)
-    "*.googlevideo.com", // YouTube video playback (https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit)
     "hwcdn.libsyn.com", // podcasts
     "traffic.libsyn.com", // podcasts
     "api*-desktop.musixmatch.com", // lyrics (genius-spicetify)
     "*.podbean.com", // podcasts
     "dts.podtrac.com", // podcasts
     "www.podtrac.com", // podcasts
+    "www.reddit.com", // Reddit (Spicetify Reddit app)
     "audio.simplecast.com", // podcasts
     "media.simplecast.com", // podcasts
     "ap.spotify.com", // audio (access point)
@@ -53,6 +51,8 @@ static const char *whitelist[] = {
     "audio-fa.spotifycdn.com", // audio
     "seed-mix-image.spotifycdn.com", // mix images
     "download.ted.com", // podcasts
+    "www.youtube.com", // YouTube (Spicetify Reddit app)
+    "i.ytimg.com", // YouTube images (Spicetify Reddit app)
     "dcs*.megaphone.fm", // podcasts
     "traffic.megaphone.fm", // podcasts
     "audio-ak-spotify-com.akamaized.net", // audio

--- a/whitelist.h
+++ b/whitelist.h
@@ -26,6 +26,10 @@ static const char *whitelist[] = {
     "platform-lookaside.fbsbx.com", // Facebook profile images
     "genius.com", // lyrics (genius-spicetify)
     "*.gvt1.com", // Widevine download
+    "www.reddit.com", // reddit content (https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit)
+    "www.youtube.com", // YouTube entry (https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit)
+    "i.ytimg.com", // YouTube thumbnail (https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit)
+    "*.googlevideo.com", // YouTube video playback (https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit)
     "hwcdn.libsyn.com", // podcasts
     "traffic.libsyn.com", // podcasts
     "api*-desktop.musixmatch.com", // lyrics (genius-spicetify)


### PR DESCRIPTION
This patch unblocks the Reddit and YouTube URLs to allow spicetify's [Reddit](https://github.com/khanhas/spicetify-cli/wiki/Custom-Apps#reddit) custom app to work with ad-blocking enabled.

![Here's the extension in action.](https://user-images.githubusercontent.com/27774996/105499969-23d89100-5cba-11eb-969b-32bd2c092981.png)

![Now with YouTube video support too!](https://user-images.githubusercontent.com/27774996/105502867-d3633280-5cbd-11eb-842c-62a636fe6258.png)

Source: https://github.com/khanhas/spicetify-cli/tree/master/CustomApps/reddit