### PR TITLE
Add whitelist entry for new spotify UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.so
 /include
+*.bz2

--- a/whitelist.h
+++ b/whitelist.h
@@ -52,5 +52,6 @@ static const char *whitelist[] = {
     "scontent*.fbcdn.net", // Facebook profile images
     "audio-sp-*.spotifycdn.net", // audio
     "dovetail.prxu.org", // podcasts
+    "gew-spclient.spotify.com", // new version main page and search
     "dovetail-cdn.prxu.org", // podcasts
 };


### PR DESCRIPTION
The new spotify ui update broke the adblocker, since some api calls from the main page and search were not in the whitelist