### PR TITLE
Update Makefile to automatically download CEF file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,34 @@ CFLAGS=-Wall -I.
 LDLIBS=-ldl
 TARGET=spotify-adblock
 PREFIX=/usr/local
+CEF_URL=https://cef-builds.spotifycdn.com
+# SAFE URL ENCODED and DECODED ("%2B" = "+")
+CEF_URL_FILE=cef_binary_89.0.15%2Bgdef70e4%2Bchromium-89.0.4389.90_linux64_minimal.tar.bz2
+CEF_FILE=cef_binary_89.0.15+gdef70e4+chromium-89.0.4389.90_linux64_minimal.tar.bz2
+
+# Dummy file to keep track of if we have extracted archive or not
+EXTRACT_CEF := $(addprefix .extract_,$(CEF_FILE))
 
 .PHONY: all
 all: $(TARGET).so
 
-$(TARGET).so: $(TARGET).c whitelist.h blacklist.h
+$(TARGET).so: $(TARGET).c whitelist.h blacklist.h | $(EXTRACT_CEF)
 	$(CC) $(CFLAGS) -shared -fPIC -o $@ $(LDFLAGS) $(LDLIBS) $^
 
 .PHONY: clean
 clean:
 	rm -f $(TARGET).so
+	rm -f $(CEF_FILE) $(CEF_FILE).sha1 $(EXTRACT_CEF)
+	rm -rf include/
+
+# Download CEF build and sha1sum of file
+$(CEF_FILE):
+	wget -N $(CEF_URL)/$(CEF_URL_FILE)
+	wget -N $(CEF_URL)/$(CEF_URL_FILE).sha1 && echo "  $(CEF_FILE)" >> $(CEF_FILE).sha1
+
+# Verify sha1sum of downloaded files and only on success continue with extract and creating dummy file
+$(EXTRACT_CEF): .extract_%: %
+	sha1sum -c $<.sha1 && tar -xf $< --wildcards '*/include' --strip-components=1 && touch $@
 
 .PHONY: install
 install: $(TARGET).so

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ LDLIBS=-ldl
 TARGET=spotify-adblock
 PREFIX=/usr/local
 CEF_URL=https://cef-builds.spotifycdn.com
+# Current stable build, as per https://cef-builds.spotifycdn.com/index.html#linux64
 # SAFE URL ENCODED and DECODED ("%2B" = "+")
-CEF_URL_FILE=cef_binary_89.0.15%2Bgdef70e4%2Bchromium-89.0.4389.90_linux64_minimal.tar.bz2
-CEF_FILE=cef_binary_89.0.15+gdef70e4+chromium-89.0.4389.90_linux64_minimal.tar.bz2
+CEF_URL_FILE=cef_binary_89.0.18%2Bgb36241d%2Bchromium-89.0.4389.114_linux64_minimal.tar.bz2
+CEF_FILE=$(subst %2B,+,$(CEF_URL_FILE))
 
 # Dummy file to keep track of if we have extracted archive or not
 EXTRACT_CEF := $(addprefix .extract_,$(CEF_FILE))


### PR DESCRIPTION
and extract the include/ folder if sha1sum is correct.
(CEF binary is also updated to cef_binary_89.0.15 which is the recommended version at time of this commit).

Added here for your consideration, (README and CI-scripts may need to be changed but I don't currently have the time for it), so feel free to use this MR or discard it..