### PR TITLE
Update whitelist

### DIFF
--- a/whitelist.h
+++ b/whitelist.h
@@ -42,6 +42,7 @@ static const char *whitelist[] = {
     "image-upload*.spotify.com", // image uploading
     "login*.spotify.com", // login
     "spclient.wg.spotify.com", // ads/tracking (blocked in blacklist), radio, recently played, friend activity,...
+    "gae-dealer.spotify.com", // home, queue
     "audio-fa.spotifycdn.com", // audio
     "seed-mix-image.spotifycdn.com", // mix images
     "download.ted.com", // podcasts


### PR DESCRIPTION
Latest update of spotify doesn't work properly without "gae-dealer.spotify.com" in whitelist.h

I haven't checked too thoroughly what things are affected by this, but at lease the home page and the queue are affected (i.e. they don't work at all)