### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 
 .PHONY: install
 install: $(TARGET).so
-	install --strip -Dm644 -t $(DESTDIR)$(PREFIX)/lib $^
+	install -Dm644 -t $(DESTDIR)$(PREFIX)/lib $^
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
Strip didn't work for me in Arch Linux (kernel 5.10.8-arch1-1; make: 4.3-3) with the following error:
╭─adam@MS-7885 /opt/spotify-adblock-linux ‹master›
╰─$ sudo make install
install --strip -Dm644 -t /usr/local/lib spotify-adblock.so
strip: /usr/local/lib/spotify-adblock.so: file format not recognized
install: strip-processen slutade onormalt
make: *** [Makefile:19: install] Fel 1

I also tried the normal strip command but it did not recognize the file either so you should probably remove it in the make.
╭─adam@MS-7885 /opt/spotify-adblock-linux ‹master*›
╰─$ sudo strip /usr/local/lib/spotify-adblock.so
strip: /usr/local/lib/spotify-adblock.so: file format not recognized