### PR TITLE
whitelist: add *.gvt1.com to install widevine

### DIFF
--- a/whitelist.h
+++ b/whitelist.h
@@ -58,4 +58,5 @@ static const char *whitelist[] = {
     "audio-sp-*.spotifycdn.net", // audio
     "dovetail.prxu.org", // podcasts
     "dovetail-cdn.prxu.org", // podcasts
+    "*.gvt1.com", // install widevine
 };


### PR DESCRIPTION
on the first start (or after `rm -rf ~/.cache/spotify`), spotify downloads the widevine DRM library

```
[+] cef_urlrequest_create:      https://redirector.gvt1.com/edgedl/widevine-cdm/4.10.1440.18-linux-x64.zip.sha256
[+] getaddrinfo:                redirector.gvt1.com
[+] getaddrinfo:                r3---sn-h0jeenek.gvt1.com
[+] cef_urlrequest_create:      https://redirector.gvt1.com/edgedl/widevine-cdm/4.10.1440.18-linux-x64.zip
[+] getaddrinfo:                r2---sn-h0jeln7l.gvt1.com
```
