### PR TITLE
use yaml config file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+    - name: Install dependencies
+      run: apt-get install libglib2.0 libglib2.0-dev libcyaml1 libcyaml-dev
     - name: Download CEF
       run: wget -O cef.tar.bz2 https://cef-builds.spotifycdn.com/cef_binary_88.1.6%2Bg4fe33a1%2Bchromium-88.0.4324.96_linux64_minimal.tar.bz2
     - name: Extract CEF headers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Install dependencies
-      run: sudo apt-get install libglib2.0 libglib2.0-dev libcyaml1 libcyaml-dev
+      run: sudo apt-get install libglib2.0 libglib2.0-dev # libcyaml1 libcyaml-dev # only in debian bullseye
+    - name: Build dependency libcyaml
+      run: apt-get source libcyaml && cd $(find * -maxdepth 0 -type d -name 'libcyaml-*' | head -n1) && make && sudo make install
     - name: Download CEF
       run: wget -O cef.tar.bz2 https://cef-builds.spotifycdn.com/cef_binary_88.1.6%2Bg4fe33a1%2Bchromium-88.0.4324.96_linux64_minimal.tar.bz2
     - name: Extract CEF headers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Install dependencies
-      run: apt-get install libglib2.0 libglib2.0-dev libcyaml1 libcyaml-dev
+      run: sudo apt-get install libglib2.0 libglib2.0-dev libcyaml1 libcyaml-dev
     - name: Download CEF
       run: wget -O cef.tar.bz2 https://cef-builds.spotifycdn.com/cef_binary_88.1.6%2Bg4fe33a1%2Bchromium-88.0.4324.96_linux64_minimal.tar.bz2
     - name: Extract CEF headers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install libglib2.0 libglib2.0-dev # libcyaml1 libcyaml-dev # only in debian bullseye
     - name: Build dependency libcyaml
-      run: apt-get source libcyaml && cd $(find * -maxdepth 0 -type d -name 'libcyaml-*' | head -n1) && make && sudo make install
+      run: wget https://github.com/tlsa/libcyaml/archive/refs/tags/v1.1.0.tar.gz && tar xvf v1.1.0.tar.gz && cd libcyaml-1.1.0 && make && sudo make install
     - name: Download CEF
       run: wget -O cef.tar.bz2 https://cef-builds.spotifycdn.com/cef_binary_88.1.6%2Bg4fe33a1%2Bchromium-88.0.4324.96_linux64_minimal.tar.bz2
     - name: Extract CEF headers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Install dependencies
-      run: sudo apt-get install libglib2.0 libglib2.0-dev # libcyaml1 libcyaml-dev # only in debian bullseye
+      run: sudo apt-get install libglib2.0 libglib2.0-dev libyaml-0-2 libyaml-dev # libcyaml1 libcyaml-dev # only in debian bullseye
     - name: Build dependency libcyaml
       run: wget https://github.com/tlsa/libcyaml/archive/refs/tags/v1.1.0.tar.gz && tar xvf v1.1.0.tar.gz && cd libcyaml-1.1.0 && make && sudo make install
     - name: Download CEF
@@ -23,3 +23,4 @@ jobs:
       with:
         name: spotify-adblock.so
         path: spotify-adblock.so
+$(shell $(PKG_CONFIG) --cflags $(LIBYAML)),)

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,37 @@
-CC=gcc
-CFLAGS=-Wall -I.
-LDLIBS=-ldl
-TARGET=spotify-adblock
-PREFIX=/usr/local
+CC = gcc
+CFLAGS = -Wall -I.
+LDLIBS = -ldl -lcef -lglib-2.0 -lyaml -lcyaml
+# we must link against libcef.so to fix "undefined symbol: cef_string_userfree_utf16_free"
+# libcef.so is provided by spotify (usually in /share/spotify)
+
+TARGET = spotify-adblock
+pname = spotify-adblock-linux
+
+prefix ?= /usr/local
+sysconfdir ?= /etc
+bindir ?= /bin
+libdir ?= /lib
+
+CDEFINES = -DSYSCONFDIR=\"$(sysconfdir)\"
 
 .PHONY: all
 all: $(TARGET).so
 
-$(TARGET).so: $(TARGET).c whitelist.h blacklist.h
-	$(CC) $(CFLAGS) -shared -fPIC -o $@ $(LDFLAGS) $(LDLIBS) $^
+$(TARGET).so: $(TARGET).c whitelist.h blacklist.h config.h
+	$(CC) $(CFLAGS) $(CDEFINES) -shared -fPIC -o $@ $(LDFLAGS) $(LDLIBS) $^
 
 .PHONY: clean
 clean:
 	rm -f $(TARGET).so
 
 .PHONY: install
-install: $(TARGET).so
-	install --strip -Dm644 -t $(DESTDIR)$(PREFIX)/lib $^
+install:
+	install -d $(DESTDIR)$(prefix)$(libdir)
+	install -t $(DESTDIR)$(prefix)$(libdir) --strip -m 644 $(TARGET).so
+	install -d $(DESTDIR)$(sysconfdir)/$(pname)
+	install -t $(DESTDIR)$(sysconfdir)/$(pname) -m 644 config.yaml
 
 .PHONY: uninstall
 uninstall:
-	rm -f $(PREFIX)/lib/$(TARGET).so
+	rm -f $(prefix)/lib/$(TARGET).so
+	rm -fr $(sysconfdir)/$(pname)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC = gcc
-CFLAGS = -Wall -I.
-LDLIBS = -ldl -lcef -lglib-2.0 -lyaml -lcyaml
+# TODO do we need libyaml? = yaml-0.1 in pkg-config
+CFLAGS = -Wall -I. $(shell pkg-config --cflags glib-2.0 libcyaml)
+LDLIBS = -ldl -lcef -lglib-2.0 -lyaml -lcyaml $(shell pkg-config --libs glib-2.0 libcyaml)
 # we must link against libcef.so to fix "undefined symbol: cef_string_userfree_utf16_free"
 # libcef.so is provided by spotify (usually in /share/spotify)
 

--- a/config.h
+++ b/config.h
@@ -1,0 +1,172 @@
+#include <stdio.h>
+#include <glib.h>
+#include <cyaml/cyaml.h>
+
+// blacklist.h + whitelist.h are included by spotify-adblock.c
+#include "blacklist.h"
+#include "whitelist.h"
+
+const ssize_t whitelist_size = sizeof(whitelist) / sizeof(whitelist[0]);
+const ssize_t blacklist_size = sizeof(blacklist) / sizeof(blacklist[0]);
+
+typedef struct {
+  int debug;
+  char **whitelist; int whitelist_count;
+  char **blacklist; int blacklist_count;
+} config_t;
+
+// cyaml schema
+// TODO why do we need to define the schema bottom-up?
+
+static const cyaml_schema_value_t stringlist_entry = {
+  CYAML_VALUE_STRING(CYAML_FLAG_POINTER, config_t, 0, CYAML_UNLIMITED),
+};
+
+static const cyaml_schema_field_t top_mapping_schema[] = {
+  CYAML_FIELD_BOOL("debug", CYAML_FLAG_DEFAULT, config_t, debug),
+  CYAML_FIELD_SEQUENCE("whitelist", CYAML_FLAG_POINTER, config_t, whitelist, &stringlist_entry, 0, CYAML_UNLIMITED),
+  CYAML_FIELD_SEQUENCE("blacklist", CYAML_FLAG_POINTER, config_t, blacklist, &stringlist_entry, 0, CYAML_UNLIMITED),
+  CYAML_FIELD_END
+};
+
+static const cyaml_schema_value_t top_schema = {
+	CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER, config_t, top_mapping_schema),
+};
+
+// cyaml config
+
+static const cyaml_config_t cyaml_config = {
+  .log_level = CYAML_LOG_WARNING, // Logging errors and warnings only.
+  .log_fn = cyaml_log,            // Use the default logging function.
+  .mem_fn = cyaml_mem,            // Use the default memory allocator.
+};
+
+
+
+// config_file will be set to path of the loaded file, or NULL if no file was loaded
+// config will be set to a config struct
+// workaround for no default values in libcyaml:
+// if config_file is NULL, we must manually free all alloc'ed memory
+// if config_file != NULL, we can use cyaml_free to free memory
+
+int load_config (char *name, config_t **config, char **config_file) {
+
+  // enable early debug by setting env var DEBUG=1
+  int early_debug = FALSE;
+  if (getenv("DEBUG") != NULL) early_debug = TRUE;
+
+  //config_t *config = NULL;
+  //char *config_file = NULL;
+
+  //const gchar *HOME = g_getenv ("HOME");
+  //printf("getenv HOME: %s\n", (HOME != NULL) ? HOME : "getenv('HOME') returned NULL");
+
+  gchar *workdir_config;
+  workdir_config = g_strconcat (name, ".yaml", NULL);
+
+  gchar *user_config;
+  const gchar *user_config_dir = g_get_user_config_dir();
+  user_config = g_strconcat (user_config_dir, "/", name, "/config.yaml", NULL);
+  g_free((void *) user_config_dir); // (void *) to free const ptr
+
+  gchar *system_config;
+  // SYSCONFDIR is defined in Makefile (usually "/etc")
+  system_config = g_strconcat (SYSCONFDIR, "/", name, "/config.yaml", NULL);
+
+  char *config_list[4];
+  config_list[0] = workdir_config;
+  config_list[1] = user_config;
+  config_list[2] = system_config;
+  config_list[3] = NULL;
+  // ideally: memcpy() file_cur to config_file and free() all those strings before return
+
+  char **file_cur;
+  for (file_cur = config_list; *file_cur != NULL; file_cur++) {
+    if (g_file_test (*file_cur, G_FILE_TEST_EXISTS) == FALSE) {
+      if (early_debug) printf("config not found: %s\n", *file_cur);
+      continue;
+    }
+    if (early_debug) printf("config found: %s\n", *file_cur);
+
+    // load config
+    cyaml_err_t cyaml_status;
+    cyaml_status = cyaml_load_file(
+      //*file_cur, &cyaml_config, &top_schema, (cyaml_data_t **) &config, NULL);
+      *file_cur, &cyaml_config, &top_schema, (cyaml_data_t **) config, NULL);
+    if (cyaml_status != CYAML_OK) {
+      printf("ERROR: %s\n", cyaml_strerror(cyaml_status));
+      //return EXIT_FAILURE;
+      return 1;
+    }
+
+    if (early_debug) printf("config loaded\n");
+    break;
+  }
+
+  if (early_debug) printf("tried all config files. *file_cur = %p, *config = %p\n", *file_cur, (void *) *config);
+
+  *config_file = *file_cur; // TODO verify
+
+  if (*file_cur == NULL) {
+    // no config found
+    // DEVEL for testing, comment line 45 in Makefile (install ... config.yaml)
+    if (early_debug) printf("no config file was found. fallback to default config\n");
+
+    // set default config
+    // workaround. libcyaml not yet supports default values
+    // https://github.com/tlsa/libcyaml/issues/96
+
+    *config = malloc(sizeof(config_t));
+
+    (*config)->debug = TRUE;
+
+    // use default values from blacklist.h + whitelist.h
+
+    int blacklist_size = 2;
+    char *blacklist[] = { "bl fallback 1", "bl fallback 2", NULL };
+    (*config)->blacklist_count = blacklist_size;
+    (*config)->blacklist = malloc((blacklist_size + 1) * sizeof(char *));
+    for (int i = 0; i < blacklist_size; i++) {
+      (*config)->blacklist[i] = (char *) blacklist[i];
+    }
+
+    int whitelist_size = 2;
+    char *whitelist[] = { "wl fallback 1", "wl fallback 2", NULL };
+    (*config)->whitelist_count = whitelist_size;
+    (*config)->whitelist = malloc((whitelist_size + 1) * sizeof(char *));
+    for (int i = 0; i < whitelist_size; i++) {
+      (*config)->whitelist[i] = (char *) whitelist[i];
+    }
+
+    // write default config to ~/.config/${name}/config.yaml (user_config)
+    g_mkdir_with_parents (g_strconcat (user_config_dir, "/", name, NULL), 0755);
+    FILE *fd_user_config = fopen(user_config, "w");
+    if (fd_user_config == NULL) {
+      if (early_debug) printf("failed to open file: %s\n", user_config);
+    }
+    else {
+      // TODO refactor. move to function, share with debug print in wrap_main (fprintf to stdout)
+      // TODO does libyaml require quoted strings? (in case the string starts with `*`)
+      fprintf(fd_user_config, "debug: %s\n", ((*config)->debug == TRUE ? "true" : "false"));
+      fprintf(fd_user_config, "whitelist:\n");
+      for (unsigned i = 0; i < (*config)->whitelist_count; i++) {
+        if ((*config)->whitelist[i][0] == '*')
+          fprintf(fd_user_config, "  - '%s'\n", (*config)->whitelist[i]); // quote string
+        else
+          fprintf(fd_user_config, "  - %s\n", (*config)->whitelist[i]);
+      }
+      fprintf(fd_user_config, "blacklist:\n");
+      for (unsigned i = 0; i < (*config)->blacklist_count; i++) {
+        if ((*config)->blacklist[i][0] == '*')
+          fprintf(fd_user_config, "  - '%s'\n", (*config)->blacklist[i]); // quote string
+        else
+          fprintf(fd_user_config, "  - %s\n", (*config)->blacklist[i]);
+      }
+      fclose(fd_user_config);
+      if (early_debug) printf("saved default config to: %s\n", user_config);
+    }
+
+  }
+  return EXIT_SUCCESS;
+}
+

--- a/config.h
+++ b/config.h
@@ -2,7 +2,6 @@
 #include <glib.h>
 #include <cyaml/cyaml.h>
 
-// blacklist.h + whitelist.h are included by spotify-adblock.c
 #include "blacklist.h"
 #include "whitelist.h"
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,70 @@
+# spotify-adblock-linux/config.yaml
+
+debug: true # print logs to stdout
+
+blacklist:
+  - https://spclient.wg.spotify.com/ads/* # ads
+  - https://spclient.wg.spotify.com/ad-logic/* # ads
+  - https://spclient.wg.spotify.com/gabo-receiver-service/* # tracking
+
+whitelist:
+  - localhost # local proxies
+  - audio-sp-*.pscdn.co # audio
+  - audio-fa.scdn.co # audio
+  - audio4-fa.scdn.co # audio
+  - charts-images.scdn.co # charts images
+  - daily-mix.scdn.co # daily mix images
+  - dailymix-images.scdn.co # daily mix images
+  - heads-fa.scdn.co # audio (heads)
+  - i.scdn.co # cover art
+  - lineup-images.scdn.co # playlists lineup images
+  - merch-img.scdn.co # merch images
+  - misc.scdn.co # miscellaneous images
+  - mosaic.scdn.co # playlist mosaic images
+  - newjams-images.scdn.co # release radar images
+  - o.scdn.co # cover art
+  - pl.scdn.co # playlist images
+  - profile-images.scdn.co # artist profile images
+  - seeded-session-images.scdn.co # radio images
+  - t.scdn.co # background images
+  - thisis-images.scdn.co # 'this is' playlists images
+  - video-fa.scdn.co # videos
+  - content.production.cdn.art19.com # podcasts
+  - rss.art19.com # podcasts
+  - '*.buzzsprout.com' # podcasts
+  - platform-lookaside.fbsbx.com # Facebook profile images
+  - genius.com # lyrics (genius-spicetify)
+  - hwcdn.libsyn.com # podcasts
+  - traffic.libsyn.com # podcasts
+  - api*-desktop.musixmatch.com # lyrics (genius-spicetify)
+  - '*.podbean.com' # podcasts
+  - dts.podtrac.com # podcasts
+  - www.podtrac.com # podcasts
+  - audio.simplecast.com # podcasts
+  - media.simplecast.com # podcasts
+  - ap.spotify.com # audio (access point)
+  - '*.ap.spotify.com' # resolved access points
+  - api.spotify.com # client APIs
+  - api-partner.spotify.com # album/artist pages
+  - xpui.app.spotify.com # user interface
+  - apresolve.spotify.com # access point resolving
+  - clienttoken.spotify.com # login
+  - '*dealer.spotify.com' # websocket connections
+  - image-upload*.spotify.com # image uploading
+  - login*.spotify.com # login
+  - '*-spclient.spotify.com' # client APIs
+  - spclient.wg.spotify.com # client APIs, ads/tracking (blocked in blacklist)
+  - audio-fa.spotifycdn.com # audio
+  - seed-mix-image.spotifycdn.com # mix images
+  - download.ted.com # podcasts
+  - dcs*.megaphone.fm # podcasts
+  - traffic.megaphone.fm # podcasts
+  - audio-ak-spotify-com.akamaized.net # audio
+  - audio4-ak-spotify-com.akamaized.net # audio
+  - heads4-ak-spotify-com.akamaized.net # audio (heads)
+  - audio4-ak.spotify.com.edgesuite.net # audio
+  - scontent*.fbcdn.net # Facebook profile images
+  - audio-sp-*.spotifycdn.net # audio
+  - dovetail.prxu.org # podcasts
+  - dovetail-cdn.prxu.org # podcasts
+

--- a/generate-config-yaml.sh
+++ b/generate-config-yaml.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+header2yaml() {
+  cat $1 | grep '^    "' | while read line
+  do
+    pattern=$(echo "$line" | cut -d'"' -f2)
+    comment=$(echo "$line" | sed 's|^.*", // ||')
+    #echo "pattern = '$pattern', comment = '$comment'" # debug
+    [ "${pattern:0:1}" = "*" ] && pattern="'$pattern'"
+    echo "  - $pattern # $comment"
+  done
+}
+
+#outfile=config.yaml
+outfile=/dev/stdout
+
+cat >>$outfile <<EOF
+# spotify-adblock-linux/config.yaml
+
+debug: true # print logs to stdout
+
+blacklist:
+$(header2yaml blacklist.h)
+
+whitelist:
+$(header2yaml whitelist.h)
+
+EOF

--- a/spotify-adblock.c
+++ b/spotify-adblock.c
@@ -5,11 +5,13 @@
 #include <netdb.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <glib.h>
+#include <cyaml/cyaml.h>
 
 #include "include/capi/cef_urlrequest_capi.h"
 
-#include "blacklist.h"
-#include "whitelist.h"
+#include "config.h"
 
 #define INIT_REAL_FUNCTION(name) \
     do { \
@@ -19,13 +21,25 @@
         } \
     } while (0)
 
+// enable early debug by setting env var DEBUG=1
+int early_debug = FALSE;
+
+//typeof(main) *real_main = NULL; // error: 'main' undeclared here (not in a function)
+//int (*real_main)(int argc, char **argv); // TODO better?
+//static int (*real_main)(int, char **, char **); // https://gist.github.com/apsun/1e144bf7639b22ff0097171fa0f8c6b1
+
+typedef int (*main_t)(int, char **, char **);
+static main_t real_main;
+
+// TODO why does typeof() work here?
 typeof(getaddrinfo) *real_getaddrinfo = NULL;
 typeof(cef_urlrequest_create) *real_cef_urlrequest_create = NULL;
 
-const ssize_t whitelist_size = sizeof(whitelist) / sizeof(whitelist[0]);
-const ssize_t blacklist_size = sizeof(blacklist) / sizeof(blacklist[0]);
+//const ssize_t whitelist_size = sizeof(whitelist) / sizeof(whitelist[0]);
+//const ssize_t blacklist_size = sizeof(blacklist) / sizeof(blacklist[0]);
 
 void __attribute__((constructor)) init(void) {
+    ////////INIT_REAL_FUNCTION(main);
     INIT_REAL_FUNCTION(getaddrinfo);
     INIT_REAL_FUNCTION(cef_urlrequest_create);
 }
@@ -39,8 +53,134 @@ bool listed(const char *item, const char *list[], ssize_t list_size) {
     return false;
 }
 
+/* FIXME
+when we wrap main() with wrap_main()
+we no longer see errors from ld
+
+TODO ask on stackoverflow.com
+__libc_start_main
+wrap main function
+symbol lookup error: /lib/spotify-adblock.so: undefined symbol: cef_string_userfree_utf16_free
+missing LDLIBS flag -lcef
+
+for example:
+when spotify-adblock.so is not linked against libcef.so
+then usually we get the error
+symbol lookup error: /lib/spotify-adblock.so: undefined symbol: cef_string_userfree_utf16_free
+
+but when main() is wrapped
+we must run our program in a debugger to see that error:
+gdb echo
+(gdb) set environment LD_PRELOAD /lib/spotify-adblock.so
+(gdb) start
+Temporary breakpoint 1 at 0x408630
+Starting program: /bin/echo
+/bin/bash: symbol lookup error: /lib/spotify-adblock.so: undefined symbol: cef_string_userfree_utf16_free
+During startup program exited with code 127.
+(gdb)
+-> error: in LDLIBS, flag -lcef is missing
+
+example 2:
+gdb echo
+(gdb) set environment LD_PRELOAD /lib/spotify-adblock.so
+(gdb) start
+Temporary breakpoint 1 at 0x408630
+Starting program: /bin/echo
+/bin/bash: error while loading shared libraries: libgobject-2.0.so.0: cannot open shared object file: No such file or directory
+During startup program exited with code 127.
+(gdb)
+-> error: LD_LIBRARY_PATH is not set (NixOS)
+
+... but such errors should be visible without a debugger
+*/
+
+config_t *config = NULL;
+char *config_file = NULL; // null: no config file was loaded
+
+int wrap_main(int argc, char **argv, char **envp) {
+
+    //config_t *config = NULL;
+    //char *config_file = NULL; // null: no config file was loaded
+
+    if (early_debug) printf("wrap main: load_config\n");
+    load_config("spotify-adblock-linux", &config, &config_file);
+
+    if (config->debug == TRUE) {
+        printf("load_config done\n");
+        printf("config_file = %s\n", config_file);
+        // print config
+        printf("config:\n");
+        printf("```yaml\n");
+        printf("debug: %s\n", (config->debug == TRUE ? "true" : "false"));
+        printf("whitelist:\n");
+        for (unsigned i = 0; i < config->whitelist_count; i++) {
+            printf("  - %s\n", config->whitelist[i]);
+        }
+        printf("blacklist:\n");
+        for (unsigned i = 0; i < config->blacklist_count; i++) {
+            printf("  - %s\n", config->blacklist[i]);
+        }
+        printf("```\n");
+    }
+
+    int main_res = real_main(argc, argv, envp);
+    if (config->debug) printf("main() returned %d\n", main_res);
+
+    // cleanup
+    // free config
+    if (config_file != NULL) {
+        // config was loaded by cyaml
+        cyaml_free(&cyaml_config, &top_schema, config, 0);
+    }
+    else {
+        // config was set manually
+        free(config->whitelist);
+        free(config->blacklist);
+        free(config);
+    }
+
+    return main_res;
+}
+
+// wrap __libc_start_main: replace real_main with wrap_main
+int __libc_start_main(
+    main_t main, int argc, char **argv,
+    //int (*init)(int, char **, char **),
+    // void (*init) (void),
+    main_t init,
+    void (*fini)(void), void (*rtld_fini)(void), void *stack_end
+) {
+    if (getenv("DEBUG") != NULL) early_debug = TRUE;
+    if (early_debug) printf("wrap __libc_start_main\n");
+
+    static int (*real___libc_start_main)() = NULL;
+    if (!real___libc_start_main) {
+        if (early_debug) printf("real___libc_start_main = %p (falsy)\n", real___libc_start_main);
+        char *error;
+        real___libc_start_main = dlsym(RTLD_NEXT, "__libc_start_main");
+        if (early_debug) printf("real___libc_start_main = %p\n", real___libc_start_main);
+        if ((error = dlerror()) != NULL) {
+            printf("%s\n", error);
+            exit(1);
+        }
+    }
+    real_main = main;
+    return real___libc_start_main(wrap_main, argc, argv, init, fini, rtld_fini, stack_end);
+
+/*
+    real_main = main;
+    typeof(&__libc_start_main) real___libc_start_main = dlsym(RTLD_NEXT, "__libc_start_main");
+    if (early_debug) printf("wrap __libc_start_main: done\n");
+    return real___libc_start_main(wrap_main, argc, argv, init, fini, rtld_fini, stack_end);
+*/
+
+}
+
+
+
 int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res) {
-    if (listed(node, whitelist, whitelist_size)) {
+    //if (listed(node, whitelist, whitelist_size)) {
+    if (listed(node, (const char **) config->whitelist, config->whitelist_count)) {
         printf("[+] getaddrinfo:\t\t%s\n", node);
         return real_getaddrinfo(node, service, hints, res);
     }
@@ -54,7 +194,8 @@ cef_urlrequest_t* cef_urlrequest_create(struct _cef_request_t* request, struct _
     url[url_utf16->length] = '\0';
     for (int i = 0; i < url_utf16->length; i++) url[i] = *(url_utf16->str + i);
     cef_string_userfree_utf16_free(url_utf16);
-    if (listed(url, blacklist, blacklist_size)) {
+    //if (listed(url, blacklist, blacklist_size)) {
+    if (listed(url, (const char **) config->blacklist, config->blacklist_count)) {
         printf("[-] cef_urlrequest_create:\t%s\n", url);
         return NULL;
     }


### PR DESCRIPTION
solve issue #119

the new version will try to load

1. workdir config: `spotify-adblock-linux.yaml`
2. user config: `~/.config/spotify-adblock-linux/config.yaml`
3. system config: `/etc/spotify-adblock-linux/config.yaml`

if no config file is found, write default values (from `blacklist.h` and `whitelist.h`) to user config file

add script `generate-config-yaml.sh` to generate `config.yaml`

allow early debug by setting env-var `DEBUG=1`

use `libcyaml` to parse yaml to c struct
default values are set manually, since libcyaml is yet lacking [that feature](https://github.com/tlsa/libcyaml/issues/96)

known issue: low-level errors like
`symbol lookup error: /lib/spotify-adblock.so: undefined symbol: cef_string_userfree_utf16_free`
or
`/bin/bash: error while loading shared libraries: libgobject-2.0.so.0: cannot open shared object file: No such file or directory`
are only printed in a debugger
but these should be visible in a regular program call
(edit: TODO verify calling wrapper vs binary executable (NixOS likes to wrap binaries))

wrapping `main` in `LD_PRELOAD` and `int __libc_start_main` is a rare scenario
but such low-level errors are even more rare, why i havent found a solution yet

i also added `-lcef` to Makefile LDLIBS to fix "undefined symbol: cef_string_userfree_utf16_free"
probably this is only an issue on my system (NixOS)
and i have to fix my LDFLAGS ... hope to fix this soon

fwiw, here is my [spotify-adblock-linux/default.nix](https://github.com/milahu/nur-packages/blob/master/pkgs/spotify-adblock-linux/default.nix) build file

edit: `fatal error: glib.h: No such file or directory`
-> probably the easiest fix is to add `pkg-config --cflags glib-2.0` to `CFLAGS`

edit: oof debian! [these](https://packages.debian.org/testing/source/libcyaml) are only in debian bullseye

> E: Unable to locate package libcyaml1
> E: Unable to locate package libcyaml-dev

could be added: CLI
`--help` to show CLI synopsis
`--adblock-print-config` to print default config to stdout
`--adblock-write-config` to write default config to ~/.config/spotify-adblock-linux/config.yaml
`--adblock-config <path>` to use config file in custom path
